### PR TITLE
[BE] feature: 로그 비동기 처리

### DIFF
--- a/BE/build.gradle
+++ b/BE/build.gradle
@@ -44,6 +44,14 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	//mysql jdbc 벤더
 	implementation 'com.mysql:mysql-connector-j'
+	implementation 'org.springframework.boot:spring-boot-starter-log4j2'
+	implementation group: 'com.lmax', name: 'disruptor', version: '3.4.4'
+}
+
+configurations {
+	all {
+		exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
+	}
 }
 
 tasks.named('test') {

--- a/BE/src/main/resources/log4j2.xml
+++ b/BE/src/main/resources/log4j2.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+<!--        <Console name="Console" target="SYSTEM_OUT">-->
+<!--            <PatternLayout pattern="%style{%d{ISO8601}}{black} %highlight{%-5level }[%style{%t}{bright,blue}] %style{%C{1.}}{bright,yellow}: %msg%n%throwable" />-->
+<!--        </Console>-->
+        <RollingRandomAccessFile name="RollingRandomAccessFile" immediateFlush="false" filePattern="logs/app-%d{yyyy-MM-dd-HH}-%i.log">
+            <PatternLayout>
+                <Pattern>%d %p %c{1.} [%t] %m %ex%n</Pattern>
+            </PatternLayout>
+            <Policies>
+                <TimeBasedTriggeringPolicy />
+                <SizeBasedTriggeringPolicy size="1000 MB"/>
+            </Policies>
+        </RollingRandomAccessFile>
+    </Appenders>
+    <Loggers>
+        <AsyncLogger name="com.softeer.BE" level="info" includeLocation="true">
+            <AppenderRef ref="RollingRandomAccessFile"/>
+        </AsyncLogger>
+        <Root level="info" includeLocation="true">
+            <AppenderRef ref="RollingRandomAccessFile"/>
+<!--            <AppenderRef ref="Console"/>-->
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
## 구현 내용
    log4j2를 사용해 로그 비동기 처리를 완료했습니다
    모든 로그를 비동기 처리하지 않고 일부를 동기 방식을 적용해 좀더 유연하게 처리할 수 있도록 구현했습니다.
    jmeter를 통해 처리량 테스트를 완료했습니다
    기존에 올렸던 pr에 불필요한 파일이 있어서 수정했습니다.
    버퍼의 사이즈를 조절해 메시지가 소실되는 상황을 예방했습니다.
    
<img width="307" alt="스크린샷 2024-02-27 오전 3 21 55" src="https://github.com/softeerbootcamp-3rd/Team5-I5NIQ/assets/111631775/be4403ac-f3bd-4ed1-bdd1-26f1da579883">

## 기타
    현재 로그가 발생시 logs 디렉토리에 log 파일을 만들고 있습니다.
    실제 배포환경에서 실행시 메모리가 부족해지는 현상이 발생할 수 있으므로 머지는 최대한 늦추겠습니다.